### PR TITLE
Add simple login management

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,38 +8,56 @@
   <script src="https://unpkg.com/html5-qrcode"></script>
 </head>
 <body>
-  <div class="container">
-    <h1>Wybierz datę</h1>
-    <input type="date" id="date-input"/>
-    <button id="load-btn">📦 Pokaż wysyłki</button>
+  <div id="login-section" class="container">
+    <h1>Logowanie</h1>
+    <input type="text" id="login-username" placeholder="Nazwa użytkownika" />
+    <input type="password" id="login-password" placeholder="Hasło" />
+    <button id="login-btn">Zaloguj</button>
+  </div>
 
-    <div id="shipments-section" class="hidden">
-      <h2>Lista wysyłek</h2>
-      <ul id="shipments"></ul>
-      <button id="scan-btn">📷 Zeskanuj SSCC</button>
+  <div id="app-section" class="hidden">
+    <div class="container">
+      <h1>Wybierz datę</h1>
+      <input type="date" id="date-input"/>
+      <button id="load-btn">📦 Pokaż wysyłki</button>
+
+      <div id="shipments-section" class="hidden">
+        <h2>Lista wysyłek</h2>
+        <ul id="shipments"></ul>
+        <button id="scan-btn">📷 Zeskanuj SSCC</button>
+      </div>
+
+      <div id="scanner" class="hidden">
+        <h2>Skanuj kod SSCC</h2>
+        <div id="reader" style="width: 100%"></div>
+      </div>
+
+      <div id="details-section" class="hidden">
+        <h2>Szczegóły przesyłki</h2>
+        <p><strong>SSCC:</strong> <span id="selected-sscc"></span></p>
+        <p><strong>Klient:</strong> <span id="selected-client"></span></p>
+
+        <label for="status">Status:</label>
+        <select id="status">
+          <option value="przyjęto">Przyjęto</option>
+          <option value="uszkodzony">Uszkodzony</option>
+          <option value="oczekuje">Oczekuje</option>
+        </select>
+
+        <label for="photo">Dodaj zdjęcie:</label>
+        <input type="file" accept="image/*" id="photo"/>
+
+        <button id="save-btn">💾 Zapisz</button>
+      </div>
     </div>
 
-    <div id="scanner" class="hidden">
-      <h2>Skanuj kod SSCC</h2>
-      <div id="reader" style="width: 100%"></div>
-    </div>
-
-    <div id="details-section" class="hidden">
-      <h2>Szczegóły przesyłki</h2>
-      <p><strong>SSCC:</strong> <span id="selected-sscc"></span></p>
-      <p><strong>Klient:</strong> <span id="selected-client"></span></p>
-
-      <label for="status">Status:</label>
-      <select id="status">
-        <option value="przyjęto">Przyjęto</option>
-        <option value="uszkodzony">Uszkodzony</option>
-        <option value="oczekuje">Oczekuje</option>
-      </select>
-
-      <label for="photo">Dodaj zdjęcie:</label>
-      <input type="file" accept="image/*" id="photo"/>
-
-      <button id="save-btn">💾 Zapisz</button>
+    <div id="user-management" class="container">
+      <h2>Użytkownicy</h2>
+      <ul id="user-list"></ul>
+      <input type="text" id="new-username" placeholder="Nazwa użytkownika" />
+      <input type="password" id="new-password" placeholder="Hasło" />
+      <button id="add-user-btn">Dodaj użytkownika</button>
+      <button id="logout-btn">Wyloguj</button>
     </div>
   </div>
   <script src="env.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,83 @@
+// Prosty skrypt do logowania i zarządzania użytkownikami
+
+document.addEventListener('DOMContentLoaded', () => {
+  const loginSection = document.getElementById('login-section');
+  const appSection = document.getElementById('app-section');
+  const loginBtn = document.getElementById('login-btn');
+  const logoutBtn = document.getElementById('logout-btn');
+
+  function getUsers() {
+    let users = JSON.parse(localStorage.getItem('users'));
+    if (!users) {
+      users = [{ username: 'admin', password: 'password' }];
+      localStorage.setItem('users', JSON.stringify(users));
+    }
+    return users;
+  }
+
+  function saveUsers(users) {
+    localStorage.setItem('users', JSON.stringify(users));
+  }
+
+  function login(username, password) {
+    return getUsers().some(u => u.username === username && u.password === password);
+  }
+
+  function renderUsers() {
+    const list = document.getElementById('user-list');
+    list.innerHTML = '';
+    getUsers().forEach((user, index) => {
+      const li = document.createElement('li');
+      li.textContent = user.username;
+      const btn = document.createElement('button');
+      btn.textContent = 'Usuń';
+      btn.addEventListener('click', () => {
+        const users = getUsers();
+        users.splice(index, 1);
+        saveUsers(users);
+        renderUsers();
+      });
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
+  }
+
+  function showApp() {
+    loginSection.classList.add('hidden');
+    appSection.classList.remove('hidden');
+    renderUsers();
+  }
+
+  loginBtn.addEventListener('click', () => {
+    const user = document.getElementById('login-username').value;
+    const pass = document.getElementById('login-password').value;
+    if (login(user, pass)) {
+      localStorage.setItem('loggedIn', 'true');
+      showApp();
+    } else {
+      alert('Błędny login lub hasło');
+    }
+  });
+
+  document.getElementById('add-user-btn').addEventListener('click', () => {
+    const user = document.getElementById('new-username').value;
+    const pass = document.getElementById('new-password').value;
+    if (!user || !pass) return;
+    const users = getUsers();
+    users.push({ username: user, password: pass });
+    saveUsers(users);
+    document.getElementById('new-username').value = '';
+    document.getElementById('new-password').value = '';
+    renderUsers();
+  });
+
+  logoutBtn.addEventListener('click', () => {
+    localStorage.setItem('loggedIn', 'false');
+    appSection.classList.add('hidden');
+    loginSection.classList.remove('hidden');
+  });
+
+  if (localStorage.getItem('loggedIn') === 'true') {
+    showApp();
+  }
+});


### PR DESCRIPTION
## Summary
- add login form section
- manage users in localStorage and support logout
- create basic `script.js` to handle login and user management

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b250c95408332bcd6d7bede3c5447